### PR TITLE
allow hacheck to bind to multiple ports

### DIFF
--- a/hacheck/main.py
+++ b/hacheck/main.py
@@ -35,8 +35,10 @@ def main():
     parser.add_option(
         '-p',
         '--port',
-        default=3333,
-        type=int
+        default=[3333],
+        action='append',
+        type=int,
+        help='Port to bind to (may be repeated)',
     )
     parser.add_option(
         '--spool-root',
@@ -71,7 +73,8 @@ def main():
     cache.configure(cache_time=config.config['cache_time'])
     spool.configure(spool_root=opts.spool_root)
     application = get_app()
-    application.listen(opts.port)
+    for p in sorted(set(opts.port)):
+        application.listen(p)
     ioloop = tornado.ioloop.IOLoop.instance()
     for sig in (signal.SIGTERM, signal.SIGQUIT, signal.SIGINT):
         signal.signal(sig, lambda *args: ioloop.stop())


### PR DESCRIPTION
If you're starting to run out of TIME-WAIT sockets, clearly the best option is to distribute across more source/dest tuples.
