### PR TITLE
show the last response in "haupdown -a list"

### DIFF
--- a/hacheck/handlers.py
+++ b/hacheck/handlers.py
@@ -33,7 +33,7 @@ class ListRecentHandler(tornado.web.RequestHandler):
         now = time.time()
         recency_threshold = int(self.get_argument('threshold', 10 * 60))
         response = []
-        for service_name, t in seen_services.iteritems():
+        for service_name, t in seen_services.items():
             if now - t > recency_threshold:
                 continue
             last_status = last_statuses.get(service_name, None)

--- a/hacheck/haupdown.py
+++ b/hacheck/haupdown.py
@@ -9,6 +9,7 @@ import os
 import pwd
 import sys
 
+import six
 from six.moves.urllib.request import urlopen
 
 import hacheck.spool
@@ -103,7 +104,7 @@ def main(default_action='status'):
         )) as f:
             resp = json.load(f)
             for s in sorted(resp['seen_services']):
-                if isinstance(s, basestring):
+                if isinstance(s, six.string_types):
                     print_s(s)
                 else:
                     service_name, last_response = s

--- a/hacheck/haupdown.py
+++ b/hacheck/haupdown.py
@@ -103,7 +103,11 @@ def main(default_action='status'):
         )) as f:
             resp = json.load(f)
             for s in sorted(resp['seen_services']):
-                print_s(s)
+                if isinstance(s, basestring):
+                    print_s(s)
+                else:
+                    service_name, last_response = s
+                    print_s('%s last_response=%s', service_name, json.dumps(last_response))
             return 0
     elif opts.action == 'up':
         hacheck.spool.configure(opts.spool_root, needs_write=True)

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -148,7 +148,17 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(200, response.code)
         response = self.fetch('/recent')
         b = json.loads(response.body.decode('utf-8'))
-        self.assertEqual(b, {'seen_services': ['foo'], 'threshold_seconds': 600})
+        self.assertEqual(
+            b,
+            {
+                'seen_services': [['foo', {'code': 200, 'ts': mock.ANY, 'remote_ip': '127.0.0.1'}]],
+                'threshold_seconds': 600
+            })
         response = self.fetch('/recent?threshold=20')
         b = json.loads(response.body.decode('utf-8'))
-        self.assertEqual(b, {'seen_services': ['foo'], 'threshold_seconds': 20})
+        self.assertEqual(
+            b,
+            {
+                'seen_services': [['foo', {'code': 200, 'ts': mock.ANY, 'remote_ip': '127.0.0.1'}]],
+                'threshold_seconds': 20
+            })


### PR DESCRIPTION
Example output:

```
% python -m hacheck.haupdown -a list
hacheck last_response={"code": 200, "ts": 1425596404.74209, "remote_ip": "127.0.0.1"}
```