### PR TITLE
Add tox.ini for running tests+flake8 against python 2.6, 2.7, 3.4. Fix flake8 issues.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ env26/
 env27/
 env32/
 env33/
+.tox/

--- a/hacheck/compat.py
+++ b/hacheck/compat.py
@@ -57,6 +57,7 @@ def nested3(*managers):
 def bchr3(c):
     return bytes((c,))
 
+
 def bchr2(c):
     return chr(c)
 

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -68,7 +68,9 @@ class TestCallable(TestCase):
 
     def test_status_downed(self):
         with self.setup_wrapper() as (spooler, mock_print):
-            spooler.status_all_down.return_value = [(sentinel_service_name, {'service': sentinel_service_name, 'reason': ''})]
+            spooler.status_all_down.return_value = [
+                (sentinel_service_name, {'service': sentinel_service_name, 'reason': ''})
+            ]
             self.assertEqual(hacheck.haupdown.status_downed(), 0)
             mock_print.assert_called_once_with("DOWN\t%s\t%s", sentinel_service_name, mock.ANY)
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -72,38 +72,45 @@ class TestHTTPChecker(tornado.testing.AsyncHTTPTestCase):
 
     @tornado.testing.gen_test
     def test_check_success(self):
-        response = yield checker.check_http("foo", self.get_http_port(), "/", io_loop=self.io_loop, query_params="", headers={})
+        response = yield checker.check_http("foo", self.get_http_port(), "/", io_loop=self.io_loop, query_params="",
+                                            headers={})
         self.assertEqual((200, b'TEST OK'), response)
 
     @tornado.testing.gen_test
     def test_check_failure(self):
-        code, response = yield checker.check_http("foo", self.get_http_port(), "/bar", io_loop=self.io_loop, query_params="", headers={})
+        code, response = yield checker.check_http("foo", self.get_http_port(), "/bar", io_loop=self.io_loop,
+                                                  query_params="", headers={})
         self.assertEqual(404, code)
 
     @tornado.testing.gen_test
     def test_check_failure_with_code(self):
-        code, response = yield checker.check_http("foo", self.get_http_port(), "/bip", io_loop=self.io_loop, query_params="", headers={})
+        code, response = yield checker.check_http("foo", self.get_http_port(), "/bip", io_loop=self.io_loop,
+                                                  query_params="", headers={})
         self.assertEqual(501, code)
 
     @tornado.testing.gen_test
     def test_check_wrong_port(self):
-        code, response = yield checker.check_http("foo", self.get_http_port() + 1, "/", io_loop=self.io_loop, query_params="", headers={})
+        code, response = yield checker.check_http("foo", self.get_http_port() + 1, "/", io_loop=self.io_loop,
+                                                  query_params="", headers={})
         self.assertEqual(599, code)
 
     @tornado.testing.gen_test
     def test_service_name_header(self):
         with mock.patch.dict(config.config, {'service_name_header': 'SName'}):
-            code, response = yield checker.check_http('service_name', self.get_http_port(), "/sname", io_loop=self.io_loop, query_params="", headers={})
+            code, response = yield checker.check_http('service_name', self.get_http_port(), "/sname",
+                                                      io_loop=self.io_loop, query_params="", headers={})
             self.assertEqual(b'service_name', response)
 
     @tornado.testing.gen_test
     def test_query_params_passed(self):
-        response = yield checker.check_http("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop, query_params="foo=bar", headers={})
+        response = yield checker.check_http("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop,
+                                            query_params="foo=bar", headers={})
         self.assertEqual((200, b'bar'), response)
 
     @tornado.testing.gen_test
     def test_query_params_not_passed(self):
-        response = yield checker.check_http("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop, query_params="", headers={})
+        response = yield checker.check_http("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop,
+                                            query_params="", headers={})
         self.assertEqual(400, response[0])
 
 
@@ -142,5 +149,6 @@ class TestTCPChecker(tornado.testing.AsyncTestCase):
     @tornado.testing.gen_test
     def test_check_failure(self):
         with mock.patch.object(checker, 'TIMEOUT', 1):
-            response = yield checker.check_tcp("foo", self.unlistened_port, None, io_loop=self.io_loop, query_params="", headers={})
+            response = yield checker.check_tcp("foo", self.unlistened_port, None, io_loop=self.io_loop, query_params="",
+                                               headers={})
             self.assertEqual(response[0], 503)

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -3,8 +3,6 @@ try:
 except ImportError:
     from unittest import TestCase
 
-#import tornado.testing
-
 from hacheck import mysql
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,11 @@ envlist = py26, py27, py34
 usedevelop=True
 basepython = python2.7
 install_command = pip install --upgrade {opts} {packages}
-deps = -rrequirements-tests.txt
+deps =
+	-rrequirements-tests.txt
+	flake8
 commands =
+	flake8 hacheck tests
 	nosetests
 
 [testenv:py27]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+basepython = python2.7
+envlist = py26, py27, py34
+
+[testenv]
+usedevelop=True
+basepython = python2.7
+install_command = pip install --upgrade {opts} {packages}
+deps = -rrequirements-tests.txt
+commands =
+	nosetests
+
+[testenv:py27]
+basepython = python2.7
+deps =
+	{[testenv]deps}
+	-rrequirements-py2.txt
+
+[testenv:py34]
+basepython = python3.4
+
+[testenv:py26]
+basepython = python2.6
+deps =
+	{[testenv]deps}
+	-rrequirements-py2.txt


### PR DESCRIPTION
I didn't see another scripted way to run tests locally (other than nosetests, which afaik doesn't set up virtualenv for you).

I've added a tox.ini, set it to run nosetests+flake8 against py2.7 and py3.4. I have a py26 section in there, but the tests don't currently pass (unittest in py26 is missing assertGreater and assertIsInstance) so I didn't include it by default.

I also cleaned up some issues that flake8 raised. 
