### PR TITLE
Added support for multiple headers via config list

### DIFF
--- a/hacheck/checker.py
+++ b/hacheck/checker.py
@@ -16,8 +16,6 @@ from . import __version__
 
 TIMEOUT = 10
 
-HTTP_HEADERS_TO_COPY = ('Host',)
-
 
 class Timeout(Exception):
     pass
@@ -84,7 +82,7 @@ def check_http(service_name, port, check_path, io_loop, query_params, headers):
     if not check_path.startswith("/"):
         check_path = "/" + check_path  # pragma: no cover
     headers_out = {'User-Agent': 'hastate %s' % (__version__)}
-    for header in HTTP_HEADERS_TO_COPY:
+    for header in config.config['http_headers_to_copy']:
         if header in headers:
             headers_out[header] = headers[header]
     if config.config['service_name_header']:

--- a/hacheck/config.py
+++ b/hacheck/config.py
@@ -15,7 +15,7 @@ DEFAULTS = {
     'mysql_username': (str, None),
     'mysql_password': (str, None),
     'rlimit_nofile': (max_or_int, None),
-    'http_headers_to_copy': (list, 'Host')
+    'http_headers_to_copy': (list, ['Host'])
 }
 
 

--- a/hacheck/config.py
+++ b/hacheck/config.py
@@ -14,7 +14,8 @@ DEFAULTS = {
     'log_path': (str, 'stderr'),
     'mysql_username': (str, None),
     'mysql_password': (str, None),
-    'rlimit_nofile': (max_or_int, None)
+    'rlimit_nofile': (max_or_int, None),
+    'http_headers_to_copy': (list, 'Host')
 }
 
 


### PR DESCRIPTION
In particular instances there might be the need to allow headers other than 'Host' to reach the hacheck endpoint. This change allows for a flexible list of allowed HTTP headers, going back to the default behaviour if this list is not provided.
