### PR TITLE
Remote control of spool; support downing specific ports; spool expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ env26/
 env27/
 env32/
 env33/
+.tox/

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Imagine you want to take down the server `web01` for maintenance. Just SSH to it
 * `mysql_username`: username to use when logging into mysql for checks
 * `mysql_password`: password to use when logging into mysql for checks
 * `rlimit_nofile`: set the NOFILE rlimit. If the string "max", will set the rlimit to the hard rlimit; otherwise, will be interpreted as an integer and set to that value.
+* `allow_remote_spool_changes`: whether to allow remote control of spool files.
 
 ### Monitoring
 

--- a/hacheck/checker.py
+++ b/hacheck/checker.py
@@ -66,7 +66,7 @@ def add_timeout_to_connect(stream, args=tuple(), kwargs=dict(), timeout_secs=TIM
 # Do not cache spool checks
 @tornado.concurrent.return_future
 def check_spool(service_name, port, query, io_loop, callback, query_params, headers):
-    up, extra_info = spool.is_up(service_name)
+    up, extra_info = spool.is_up(service_name, port=port)
     if not up:
         info_string = 'Service %s in down state' % (extra_info['service'],)
         if extra_info.get('reason', ''):

--- a/hacheck/checker.py
+++ b/hacheck/checker.py
@@ -69,6 +69,10 @@ def check_spool(service_name, port, query, io_loop, callback, query_params, head
     up, extra_info = spool.is_up(service_name, port=port)
     if not up:
         info_string = 'Service %s in down state' % (extra_info['service'],)
+        if extra_info.get('creation') is not None:
+            info_string += ' since %f' % extra_info['creation']
+        if extra_info.get('expiration') is not None:
+            info_string += ' until %f' % extra_info['expiration']
         if extra_info.get('reason', ''):
             info_string += ": %s" % extra_info['reason']
         callback((503, info_string))

--- a/hacheck/compat.py
+++ b/hacheck/compat.py
@@ -57,6 +57,7 @@ def nested3(*managers):
 def bchr3(c):
     return bytes((c,))
 
+
 def bchr2(c):
     return chr(c)
 

--- a/hacheck/config.py
+++ b/hacheck/config.py
@@ -14,7 +14,8 @@ DEFAULTS = {
     'log_path': (str, 'stderr'),
     'mysql_username': (str, None),
     'mysql_password': (str, None),
-    'rlimit_nofile': (max_or_int, None)
+    'rlimit_nofile': (max_or_int, None),
+    'allow_remote_spool_changes': (bool, False),
 }
 
 

--- a/hacheck/handlers.py
+++ b/hacheck/handlers.py
@@ -123,7 +123,10 @@ class SpoolServiceHandler(BaseServiceHandler):
             if expiration is not None:
                 expiration = float(expiration)
             reason = self.get_argument('reason')
-            spool.down(service_name, reason=reason, port=port, expiration=expiration)
+            creation = self.get_argument('creation', None)
+            if creation is not None:
+                creation = float(creation)
+            spool.down(service_name, reason=reason, port=port, expiration=expiration, creation=creation)
         else:
             self.set_status(400)
             self.write("status must be up or down")

--- a/hacheck/haupdown.py
+++ b/hacheck/haupdown.py
@@ -40,6 +40,17 @@ def print_s(fmt_string, *formats):
     print(fmt_string % formats)
 
 
+def print_status(service_name, is_up, info_dict):
+    """Print a status line for a given service"""
+    if is_up:
+        print_s('UP\t%s', service_name)
+    else:
+        expiration = info_dict.get('expiration')
+        if expiration is None:
+            expiration = float('Inf')
+        print_s('DOWN\t%f\t%s\t%s', expiration, service_name, info_dict.get('reason', ''))
+
+
 def main(default_action='list'):
     ACTIONS = ('up', 'down', 'status', 'status_downed', 'list')
     parser = optparse.OptionParser(usage='%prog [options] service_name(s)')
@@ -62,6 +73,20 @@ def main(default_action='list'):
         type=str,
         default="",
         help='Reason string when setting down'
+    )
+    parser.add_option(
+        '-e',
+        '--expiration',
+        type=float,
+        default=None,
+        help='Expiration time (unix time) when setting down',
+    )
+    parser.add_option(
+        '-P',
+        '--service-port',
+        type=int,
+        default=None,
+        help='Port to check/set status for',
     )
     parser.add_option(
         '-p',
@@ -116,27 +141,25 @@ def main(default_action='list'):
     elif opts.action == 'up':
         hacheck.spool.configure(opts.spool_root, needs_write=True)
         for service_name in service_names:
-            hacheck.spool.up(service_name)
+            hacheck.spool.up(service_name, port=opts.service_port)
         return 0
     elif opts.action == 'down':
         hacheck.spool.configure(opts.spool_root, needs_write=True)
         for service_name in service_names:
-            hacheck.spool.down(service_name, opts.reason)
+            hacheck.spool.down(service_name, opts.reason, expiration=opts.expiration, port=opts.service_port)
         return 0
     elif opts.action == 'status_downed':
         hacheck.spool.configure(opts.spool_root, needs_write=False)
         for service_name, info in hacheck.spool.status_all_down():
-            print_s('DOWN\t%s\t%s', service_name, info.get('reason', ''))
+            print_status(service_name, False, info)
         return 0
     else:
         hacheck.spool.configure(opts.spool_root, needs_write=False)
         rv = 0
         for service_name in service_names:
             status, info = hacheck.spool.status(service_name)
-            if status:
-                print_s('UP\t%s', service_name)
-            else:
-                print_s('DOWN\t%s\t%s', service_name, info.get('reason', ''))
+            print_status(service_name, status, info)
+            if not status:
                 rv = 1
         return rv
 

--- a/hacheck/haupdown.py
+++ b/hacheck/haupdown.py
@@ -40,7 +40,7 @@ def print_s(fmt_string, *formats):
     print(fmt_string % formats)
 
 
-def print_status(service_name, is_up, info_dict):
+def print_status(service_name, port, is_up, info_dict):
     """Print a status line for a given service"""
     if is_up:
         print_s('UP\t%s', service_name)
@@ -48,7 +48,10 @@ def print_status(service_name, is_up, info_dict):
         expiration = info_dict.get('expiration')
         if expiration is None:
             expiration = float('Inf')
-        print_s('DOWN\t%f\t%s\t%s', expiration, service_name, info_dict.get('reason', ''))
+        if port is not None:
+            print_s('DOWN\t%f\t%s:%d\t%s', expiration, service_name, port, info_dict.get('reason', ''))
+        else:
+            print_s('DOWN\t%f\t%s\t%s', expiration, service_name, info_dict.get('reason', ''))
 
 
 def main(default_action='list'):
@@ -150,15 +153,15 @@ def main(default_action='list'):
         return 0
     elif opts.action == 'status_downed':
         hacheck.spool.configure(opts.spool_root, needs_write=False)
-        for service_name, info in hacheck.spool.status_all_down():
-            print_status(service_name, False, info)
+        for service_name, port, info in hacheck.spool.status_all_down():
+            print_status(service_name, port, False, info)
         return 0
     else:
         hacheck.spool.configure(opts.spool_root, needs_write=False)
         rv = 0
         for service_name in service_names:
-            status, info = hacheck.spool.status(service_name)
-            print_status(service_name, status, info)
+            status, info = hacheck.spool.status(service_name, port=opts.service_port)
+            print_status(service_name, opts.service_port, status, info)
             if not status:
                 rv = 1
         return rv

--- a/hacheck/spool.py
+++ b/hacheck/spool.py
@@ -118,5 +118,13 @@ def up(service_name, port=None):
 
 
 def down(service_name, reason="", port=None, expiration=None, creation=None):
+    currently_up, info = status(service_name, port=port)
+
+    # If we already downed the service for the same reason, leave the creation time alone. This allows a user to
+    # repeatedly down a service to refresh its expiration time, and we will keep track of how long it has been down
+    # for.
+    if creation is None and (not currently_up) and reason == info['reason']:
+        creation = info.get('creation', creation)
+
     with open(spool_file_path(service_name, port), 'w') as f:
         f.write(serialize_spool_file_contents(reason, expiration=expiration, creation=creation))

--- a/hacheck/spool.py
+++ b/hacheck/spool.py
@@ -29,10 +29,11 @@ def parse_spool_file_path(path):
     return service_name, port
 
 
-def serialize_spool_file_contents(reason, expiration=None):
+def serialize_spool_file_contents(reason, expiration=None, creation=None):
     return json.dumps({
         "reason": reason,
         "expiration": expiration,
+        "creation": (time.time() if creation is None else creation),
     })
 
 
@@ -44,6 +45,7 @@ def deserialize_spool_file_contents(contents):
         return {
             "reason": contents,
             "expiration": None,
+            "creation": None,
         }
 
 
@@ -115,6 +117,6 @@ def up(service_name, port=None):
         pass
 
 
-def down(service_name, reason="", port=None, expiration=None):
+def down(service_name, reason="", port=None, expiration=None, creation=None):
     with open(spool_file_path(service_name, port), 'w') as f:
-        f.write(serialize_spool_file_contents(reason, expiration))
+        f.write(serialize_spool_file_contents(reason, expiration=expiration, creation=creation))

--- a/hacheck/spool.py
+++ b/hacheck/spool.py
@@ -107,7 +107,7 @@ def status_all_down():
         service_name, port = parse_spool_file_path(filename)
         up, info = status(service_name, port=port)
         if not up:
-            yield service_name, info
+            yield service_name, port, info
 
 
 def up(service_name, port=None):

--- a/hacheck/spool.py
+++ b/hacheck/spool.py
@@ -1,8 +1,50 @@
+import json
 import os
+import time
 
 config = {
     'spool_root': None,
 }
+
+
+def spool_file_path(service_name, port):
+    if port is None:
+        base_name = service_name
+    else:
+        base_name = "%s:%s" % (service_name, port)
+
+    return os.path.join(config['spool_root'], base_name)
+
+
+def parse_spool_file_path(path):
+    base_name = os.path.basename(path)
+
+    if ':' in base_name:
+        service_name, port = base_name.rsplit(':', 1)
+        port = int(port)
+    else:
+        service_name = base_name
+        port = None
+
+    return service_name, port
+
+
+def serialize_spool_file_contents(reason, expiration=None):
+    return json.dumps({
+        "reason": reason,
+        "expiration": expiration,
+    })
+
+
+def deserialize_spool_file_contents(contents):
+    try:
+        return json.loads(contents)
+    except ValueError:
+        # in case we're looking at a file created by earlier versions of hacheck
+        return {
+            "reason": contents,
+            "expiration": None,
+        }
 
 
 def configure(spool_root, needs_write=False):
@@ -15,7 +57,7 @@ def configure(spool_root, needs_write=False):
     config['spool_root'] = spool_root
 
 
-def is_up(service_name):
+def is_up(service_name, port=None):
     """Check whether a service is asserted to be up or down. Includes the logic
     for checking system-wide all state
 
@@ -23,23 +65,35 @@ def is_up(service_name):
     """
     all_up, all_info = status("all")
     if all_up:
-        return status(service_name)
+        # Check with port=None first, because if service foo is down, then service foo on port 123 should be down too.
+        service_up, service_info = status(service_name, port=None)
+        if service_up:
+            return status(service_name, port=port)
+        else:
+            return service_up, service_info
     else:
         return all_up, all_info
 
 
-def status(service_name):
+def status(service_name, port=None):
     """Check whether a service is asserted to be up or down, without checking
     the system-wide 'all' state.
 
     :returns: (bool of service status, dict of extra information)
     """
+    happy_retval = (True, {'service': service_name, 'reason': '', 'expiration': None})
+    path = spool_file_path(service_name, port)
     try:
-        with open(os.path.join(config['spool_root'], service_name), 'r') as f:
-            reason = f.read()
-            return False, {'service': service_name, 'reason': reason}
+        with open(path, 'r') as f:
+            info_dict = deserialize_spool_file_contents(f.read())
+            info_dict['service'] = service_name
+            expiration = info_dict.get('expiration')
+            if expiration is not None and expiration < time.time():
+                os.remove(path)
+                return happy_retval
+            return False, info_dict
     except IOError:
-        return True, {'service': service_name, 'reason': ''}
+        return happy_retval
 
 
 def status_all_down():
@@ -47,19 +101,20 @@ def status_all_down():
 
     :returns: Iterable of pairs of (service name, dict of extra information)
     """
-    for service_name in os.listdir(config['spool_root']):
-        up, info = status(service_name)
+    for filename in os.listdir(config['spool_root']):
+        service_name, port = parse_spool_file_path(filename)
+        up, info = status(service_name, port=port)
         if not up:
             yield service_name, info
 
 
-def up(service_name):
+def up(service_name, port=None):
     try:
-        os.unlink(os.path.join(config['spool_root'], service_name))
+        os.unlink(spool_file_path(service_name, port))
     except OSError:
         pass
 
 
-def down(service_name, reason=""):
-    with open(os.path.join(config['spool_root'], service_name), 'w') as f:
-        f.write(reason)
+def down(service_name, reason="", port=None, expiration=None):
+    with open(spool_file_path(service_name, port), 'w') as f:
+        f.write(serialize_spool_file_contents(reason, expiration))

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -81,6 +81,14 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
             response = self.fetch('/spool/foo/1/status')
             self.assertEqual(response.code, 503)
             self.assertEqual(response.body, b'Service any in down state: just because')
+        with mock.patch.object(
+            spool,
+            'is_up',
+            return_value=(False, {"service": "any", "reason": "reason", "expiration": 5, "creation": 4})
+        ):
+            response = self.fetch('/spool/foo/1/status')
+            self.assertEqual(response.code, 503)
+            self.assertRegexpMatches(response.body, b'^Service any in down state since 4\.0+ until 5\.0+: reason$')
 
     def test_calls_all_checkers(self):
         rv1 = tornado.concurrent.Future()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -196,10 +196,10 @@ class ApplicationTestCase(tornado.testing.AsyncHTTPTestCase):
 
             response = self.fetch('/spool/foo/1234/status', method='POST', body="status=down&reason=because")
             self.assertEqual(response.code, 200)
-            spool_down.assert_called_once_with('foo', reason='because', port=1234, expiration=None)
+            spool_down.assert_called_once_with('foo', reason='because', port=1234, expiration=None, creation=None)
 
             spool_down.reset_mock()
             response = self.fetch('/spool/foo/1234/status', method='POST',
-                                  body="status=down&reason=because&expiration=1")
+                                  body="status=down&reason=because&expiration=1&creation=2")
             self.assertEqual(response.code, 200)
-            spool_down.assert_called_once_with('foo', reason='because', port=1234, expiration=1)
+            spool_down.assert_called_once_with('foo', reason='because', port=1234, expiration=1, creation=2)

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -36,12 +36,18 @@ class TestCallable(TestCase):
             mock_print.assert_any_call('UP\t%s', sentinel_service_name)
             spooler.status.return_value = (False, {'reason': 'irrelevant'})
             self.assertEqual(1, hacheck.haupdown.main('status'))
-            mock_print.assert_any_call('DOWN\t%s\t%s', sentinel_service_name, 'irrelevant')
+            mock_print.assert_any_call('DOWN\t%f\t%s\t%s', float('Inf'), sentinel_service_name, 'irrelevant')
 
     def test_up(self):
         with self.setup_wrapper([sentinel_service_name]) as (spooler, mock_print):
             hacheck.haupdown.up()
-            spooler.up.assert_called_once_with(sentinel_service_name)
+            spooler.up.assert_called_once_with(sentinel_service_name, port=None)
+            self.assertEqual(mock_print.call_count, 0)
+
+    def test_up_with_port(self):
+        with self.setup_wrapper(['-P', '1234', sentinel_service_name]) as (spooler, mock_print):
+            hacheck.haupdown.up()
+            spooler.up.assert_called_once_with(sentinel_service_name, port=1234)
             self.assertEqual(mock_print.call_count, 0)
 
     def test_down(self):
@@ -49,14 +55,25 @@ class TestCallable(TestCase):
         os.environ['SUDO_USER'] = 'testyuser'
         with self.setup_wrapper([sentinel_service_name]) as (spooler, mock_print):
             hacheck.haupdown.down()
-            spooler.down.assert_called_once_with(sentinel_service_name,
-                                                 'testyuser')
+            spooler.down.assert_called_once_with(sentinel_service_name, 'testyuser', expiration=None, port=None)
             self.assertEqual(mock_print.call_count, 0)
 
     def test_down_with_reason(self):
         with self.setup_wrapper(['-r', 'something', sentinel_service_name]) as (spooler, mock_print):
             hacheck.haupdown.down()
-            spooler.down.assert_called_once_with(sentinel_service_name, 'something')
+            spooler.down.assert_called_once_with(sentinel_service_name, 'something', expiration=None, port=None)
+            self.assertEqual(mock_print.call_count, 0)
+
+    def test_down_with_expiration(self):
+        with self.setup_wrapper(['-e', '9876543210', sentinel_service_name]) as (spooler, mock_print):
+            hacheck.haupdown.down()
+            spooler.down.assert_called_once_with(sentinel_service_name, 'testyuser', expiration=9876543210, port=None)
+            self.assertEqual(mock_print.call_count, 0)
+
+    def test_down_with_port(self):
+        with self.setup_wrapper(['-P', '1234', sentinel_service_name]) as (spooler, mock_print):
+            hacheck.haupdown.down()
+            spooler.down.assert_called_once_with(sentinel_service_name, 'testyuser', expiration=None, port=1234)
             self.assertEqual(mock_print.call_count, 0)
 
     def test_status(self):
@@ -69,10 +86,18 @@ class TestCallable(TestCase):
     def test_status_downed(self):
         with self.setup_wrapper() as (spooler, mock_print):
             spooler.status_all_down.return_value = [
-                (sentinel_service_name, {'service': sentinel_service_name, 'reason': ''})
+                (sentinel_service_name, {'service': sentinel_service_name, 'reason': '', 'expiration': None})
             ]
             self.assertEqual(hacheck.haupdown.status_downed(), 0)
-            mock_print.assert_called_once_with("DOWN\t%s\t%s", sentinel_service_name, mock.ANY)
+            mock_print.assert_called_once_with("DOWN\t%f\t%s\t%s", float('Inf'), sentinel_service_name, mock.ANY)
+
+    def test_status_downed_expiration(self):
+        with self.setup_wrapper() as (spooler, mock_print):
+            spooler.status_all_down.return_value = [
+                (sentinel_service_name, {'service': sentinel_service_name, 'reason': '', 'expiration': 9876543210})
+            ]
+            self.assertEqual(hacheck.haupdown.status_downed(), 0)
+            mock_print.assert_called_once_with("DOWN\t%f\t%s\t%s", 9876543210, sentinel_service_name, mock.ANY)
 
     def test_list(self):
         with self.setup_wrapper() as (spooler, mock_print):

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -68,7 +68,9 @@ class TestCallable(TestCase):
 
     def test_status_downed(self):
         with self.setup_wrapper() as (spooler, mock_print):
-            spooler.status_all_down.return_value = [(sentinel_service_name, {'service': sentinel_service_name, 'reason': ''})]
+            spooler.status_all_down.return_value = [
+                (sentinel_service_name, {'service': sentinel_service_name, 'reason': ''})
+            ]
             self.assertEqual(hacheck.haupdown.status_downed(), 0)
             mock_print.assert_called_once_with("DOWN\t%s\t%s", sentinel_service_name, mock.ANY)
 

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -47,17 +47,19 @@ class EchoParamFoo(tornado.web.RequestHandler):
 
 class TestChecker(TestCase):
     def test_spool_success(self):
-        with mock.patch.object(spool, 'is_up', return_value=(True, {})):
+        with mock.patch.object(spool, 'is_up', return_value=(True, {})) as is_up_patch:
             fut = checker.check_spool(se.name, se.port, se.query, None, query_params=None, headers={})
             self.assertIsInstance(fut, tornado.concurrent.Future)
             self.assertTrue(fut.done())
             res = fut.result()
             self.assertEqual(res[0], 200)
+            is_up_patch.assert_called_once_with(se.name, port=se.port)
 
     def test_spool_failure(self):
-        with mock.patch.object(spool, 'is_up', return_value=(False, {'service': se.service})):
+        with mock.patch.object(spool, 'is_up', return_value=(False, {'service': se.service})) as is_up_patch:
             fut = checker.check_spool(se.name, se.port, se.query, None, query_params=None, headers={})
             self.assertEqual(fut.result()[0], 503)
+            is_up_patch.assert_called_once_with(se.name, port=se.port)
 
 
 class TestHTTPChecker(tornado.testing.AsyncHTTPTestCase):

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -72,38 +72,45 @@ class TestHTTPChecker(tornado.testing.AsyncHTTPTestCase):
 
     @tornado.testing.gen_test
     def test_check_success(self):
-        response = yield checker.check_http("foo", self.get_http_port(), "/", io_loop=self.io_loop, query_params="", headers={})
+        response = yield checker.check_http("foo", self.get_http_port(), "/", io_loop=self.io_loop, query_params="",
+                                            headers={})
         self.assertEqual((200, b'TEST OK'), response)
 
     @tornado.testing.gen_test
     def test_check_failure(self):
-        code, response = yield checker.check_http("foo", self.get_http_port(), "/bar", io_loop=self.io_loop, query_params="", headers={})
+        code, response = yield checker.check_http("foo", self.get_http_port(), "/bar", io_loop=self.io_loop,
+                                                  query_params="", headers={})
         self.assertEqual(404, code)
 
     @tornado.testing.gen_test
     def test_check_failure_with_code(self):
-        code, response = yield checker.check_http("foo", self.get_http_port(), "/bip", io_loop=self.io_loop, query_params="", headers={})
+        code, response = yield checker.check_http("foo", self.get_http_port(), "/bip", io_loop=self.io_loop,
+                                                  query_params="", headers={})
         self.assertEqual(501, code)
 
     @tornado.testing.gen_test
     def test_check_wrong_port(self):
-        code, response = yield checker.check_http("foo", self.get_http_port() + 1, "/", io_loop=self.io_loop, query_params="", headers={})
+        code, response = yield checker.check_http("foo", self.get_http_port() + 1, "/", io_loop=self.io_loop,
+                                                  query_params="", headers={})
         self.assertEqual(599, code)
 
     @tornado.testing.gen_test
     def test_service_name_header(self):
         with mock.patch.dict(config.config, {'service_name_header': 'SName'}):
-            code, response = yield checker.check_http('service_name', self.get_http_port(), "/sname", io_loop=self.io_loop, query_params="", headers={})
+            code, response = yield checker.check_http('service_name', self.get_http_port(), "/sname",
+                                                      io_loop=self.io_loop, query_params="", headers={})
             self.assertEqual(b'service_name', response)
 
     @tornado.testing.gen_test
     def test_query_params_passed(self):
-        response = yield checker.check_http("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop, query_params="foo=bar", headers={})
+        response = yield checker.check_http("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop,
+                                            query_params="foo=bar", headers={})
         self.assertEqual((200, b'bar'), response)
 
     @tornado.testing.gen_test
     def test_query_params_not_passed(self):
-        response = yield checker.check_http("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop, query_params="", headers={})
+        response = yield checker.check_http("foo", self.get_http_port(), "/echo_foo", io_loop=self.io_loop,
+                                            query_params="", headers={})
         self.assertEqual(400, response[0])
 
 
@@ -142,5 +149,6 @@ class TestTCPChecker(tornado.testing.AsyncTestCase):
     @tornado.testing.gen_test
     def test_check_failure(self):
         with mock.patch.object(checker, 'TIMEOUT', 1):
-            response = yield checker.check_tcp("foo", self.unlistened_port, None, io_loop=self.io_loop, query_params="", headers={})
+            response = yield checker.check_tcp("foo", self.unlistened_port, None, io_loop=self.io_loop, query_params="",
+                                               headers={})
             self.assertEqual(response[0], 503)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,7 +68,7 @@ class TestIntegration(tornado.testing.AsyncHTTPTestCase):
         hacheck.spool.down('test_app', 'TESTING')
         response = self.fetch('/http/test_app/%d/pinged' % self.get_http_port())
         self.assertEqual(503, response.code)
-        self.assertEqual(b'Service test_app in down state: TESTING', response.body)
+        self.assertRegexpMatches(response.body, b'^Service test_app in down state since (\d|\.)*: TESTING$')
         hacheck.spool.up('test_app')
         response = self.fetch('/http/test_app/%d/pinged' % self.get_http_port())
         self.assertEqual(b'PONG', response.body)

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -3,8 +3,6 @@ try:
 except ImportError:
     from unittest import TestCase
 
-#import tornado.testing
-
 from hacheck import mysql
 
 

--- a/tests/test_spool.py
+++ b/tests/test_spool.py
@@ -60,7 +60,7 @@ class TestSpool(TestCase):
         spool.down('foo')
         self.assertEqual(
             list(spool.status_all_down()),
-            [('foo', {'service': 'foo', 'reason': '', 'expiration': None, 'creation': mock.ANY})]
+            [('foo', None, {'service': 'foo', 'reason': '', 'expiration': None, 'creation': mock.ANY})]
         )
 
     def test_repeated_ups_works(self):

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,11 @@ envlist = py26, py27, py34
 usedevelop=True
 basepython = python2.7
 install_command = pip install --upgrade {opts} {packages}
-deps = -rrequirements-tests.txt
+deps =
+	-rrequirements-tests.txt
+	flake8
 commands =
+	flake8 hacheck tests
 	nosetests
 
 [testenv:py27]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+basepython = python2.7
+envlist = py26, py27, py34
+
+[testenv]
+usedevelop=True
+basepython = python2.7
+install_command = pip install --upgrade {opts} {packages}
+deps = -rrequirements-tests.txt
+commands =
+	nosetests
+
+[testenv:py27]
+basepython = python2.7
+deps =
+	{[testenv]deps}
+	-rrequirements-py2.txt
+
+[testenv:py34]
+basepython = python3.4
+
+[testenv:py26]
+basepython = python2.6
+deps =
+	{[testenv]deps}
+	-rrequirements-py2.txt


### PR DESCRIPTION
This branch adds 3 primary features:
- The ability to down specific ports of a service.
- Optionally (gated by a config flag), POSTs to `/spool/<service>/<port>/<query>` will up or down a service remotely.
- Spool files can have an expiration date; if hacheck reads the file after its expiration, we delete it. We also keep track of creation time.

This branch also includes my changes from #23 so I could run tests.
