### PR TITLE
fix python 3 support

### DIFF
--- a/hacheck/haupdown.py
+++ b/hacheck/haupdown.py
@@ -103,7 +103,7 @@ def main(default_action='list'):
 
     if opts.action == 'list':
         with contextlib.closing(urlopen(
-            'http://127.0.0.1:%d/recent' % opts.port,
+            'http://127.0.0.1:{0:d}/recent'.format(opts.port),
             timeout=3
         )) as f:
             reader = codecs.getreader('utf-8')

--- a/hacheck/haupdown.py
+++ b/hacheck/haupdown.py
@@ -2,6 +2,7 @@
 
 from __future__ import print_function
 
+import codecs
 import contextlib
 import json
 import optparse
@@ -105,7 +106,8 @@ def main(default_action='list'):
             'http://127.0.0.1:%d/recent' % opts.port,
             timeout=3
         )) as f:
-            resp = json.load(f)
+            reader = codecs.getreader('utf-8')
+            resp = json.load(reader(f))
             for s in sorted(resp['seen_services']):
                 if isinstance(s, six.string_types):
                     print_s(s)

--- a/requirements-py2.txt
+++ b/requirements-py2.txt
@@ -1,1 +1,2 @@
 unittest2
+futures

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 tornado>=3.0.1,<4.2
-futures
 PyYAML>=3.0
 six>=1.4.0

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,35 @@
 #!/usr/bin/env python
 import collections
+import sys
 
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
+from pip.download import PipSession
 
 
-def get_install_requirements():
+def get_install_requirements(path):
 
-    ReqOpts = collections.namedtuple('ReqOpts', ['skip_requirements_regex', 'default_vcs'])
+    ReqOpts = collections.namedtuple('ReqOpts', ['skip_requirements_regex', 'default_vcs', 'isolated_mode'])
 
-    opts = ReqOpts(None, 'git')
+    opts = ReqOpts(None, 'git', False)
 
     requires = []
     dependency_links = []
 
-    for ir in parse_requirements('requirements.txt', options=opts):
+    session = PipSession()
+
+    for ir in parse_requirements(path, options=opts, session=session):
         if ir is not None:
-            if ir.url is not None:
-                dependency_links.append(str(ir.url))
+            if getattr(ir, 'url', getattr(ir, 'link', None)) is not None:
+                dependency_links.append(str(getattr(ir, 'url', getattr(ir, 'link'))))
             if ir.req is not None:
                 requires.append(str(ir.req))
     return requires, dependency_links
 
 
-install_requires, dependency_links = get_install_requirements()
+install_requires, dependency_links = get_install_requirements('requirements.txt')
+if sys.version_info < (3, 0, 0):
+    install_requires += get_install_requirements('requirements-py2.txt')[0]
 
 setup(
     name="hacheck",

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -9,6 +9,8 @@ from unittest import TestCase
 import hacheck.haupdown
 import hacheck.spool
 
+from six.moves import StringIO
+
 # can't use an actual mock.sentinel because it doesn't support string ops
 sentinel_service_name = 'testing_service_name'
 
@@ -75,10 +77,10 @@ class TestCallable(TestCase):
     def test_list(self):
         with self.setup_wrapper() as (spooler, mock_print):
             with mock.patch.object(hacheck.haupdown, 'urlopen') as mock_urlopen:
-                mock_urlopen.return_value.read.return_value = json.dumps({
+                mock_urlopen.return_value = StringIO(json.dumps({
                     "seen_services": ["foo"],
                     "threshold_seconds": 10,
-                }).encode('utf-8')
+                }).encode('utf-8'))
                 self.assertEqual(hacheck.haupdown.halist(), 0)
                 mock_urlopen.assert_called_once_with('http://127.0.0.1:3333/recent', timeout=mock.ANY)
                 mock_print.assert_called_once_with("foo")

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 import hacheck.haupdown
 import hacheck.spool
 
-from six.moves import StringIO
+from six import BytesIO
 
 # can't use an actual mock.sentinel because it doesn't support string ops
 sentinel_service_name = 'testing_service_name'
@@ -70,14 +70,16 @@ class TestCallable(TestCase):
 
     def test_status_downed(self):
         with self.setup_wrapper() as (spooler, mock_print):
-            spooler.status_all_down.return_value = [(sentinel_service_name, {'service': sentinel_service_name, 'reason': ''})]
+            spooler.status_all_down.return_value = [
+                (sentinel_service_name, {'service': sentinel_service_name, 'reason': ''})
+            ]
             self.assertEqual(hacheck.haupdown.status_downed(), 0)
             mock_print.assert_called_once_with("DOWN\t%s\t%s", sentinel_service_name, mock.ANY)
 
     def test_list(self):
         with self.setup_wrapper() as (spooler, mock_print):
             with mock.patch.object(hacheck.haupdown, 'urlopen') as mock_urlopen:
-                mock_urlopen.return_value = StringIO(json.dumps({
+                mock_urlopen.return_value = BytesIO(json.dumps({
                     "seen_services": ["foo"],
                     "threshold_seconds": 10,
                 }).encode('utf-8'))

--- a/tests/test_callables.py
+++ b/tests/test_callables.py
@@ -78,7 +78,7 @@ class TestCallable(TestCase):
                 mock_urlopen.return_value.read.return_value = json.dumps({
                     "seen_services": ["foo"],
                     "threshold_seconds": 10,
-                })
+                }).encode('utf-8')
                 self.assertEqual(hacheck.haupdown.halist(), 0)
                 mock_urlopen.assert_called_once_with('http://127.0.0.1:3333/recent', timeout=mock.ANY)
                 mock_print.assert_called_once_with("foo")


### PR DESCRIPTION
Adds compatibility with pip7 and moves `futures` into the python 2.x requirements file (since it's built-in on python 3.2 and above and the one in pip doesn't work at all under py3.4/py3.5)
