### PR TITLE
No redirects, please

### DIFF
--- a/hacheck/checker.py
+++ b/hacheck/checker.py
@@ -94,7 +94,8 @@ def check_http(service_name, port, check_path, io_loop, query_params, headers):
         path,
         method='GET',
         headers=headers_out,
-        request_timeout=TIMEOUT
+        request_timeout=TIMEOUT,
+        follow_redirects=False,
     )
     http_client = tornado.httpclient.AsyncHTTPClient(io_loop=io_loop)
     try:

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -39,6 +39,11 @@ class ReturnFiveOhOne(tornado.web.RequestHandler):
         self.set_status(501)
         self.write(b'NOPE')
 
+class ReturnThreeOhOne(tornado.web.RequestHandler):
+    def get(self):
+        self.set_status(301)
+        self.set_header('Location', '/')
+
 
 class EchoParamFoo(tornado.web.RequestHandler):
     def get(self):
@@ -66,6 +71,7 @@ class TestHTTPChecker(tornado.testing.AsyncHTTPTestCase):
         return tornado.web.Application([
             ('/', ReturnTwoHundred),
             ('/sname', ExpectServiceNameHeader),
+            ('/redirect', ReturnThreeOhOne),
             ('/bip', ReturnFiveOhOne),
             ('/echo_foo', EchoParamFoo),
         ])
@@ -79,6 +85,11 @@ class TestHTTPChecker(tornado.testing.AsyncHTTPTestCase):
     def test_check_failure(self):
         code, response = yield checker.check_http("foo", self.get_http_port(), "/bar", io_loop=self.io_loop, query_params="", headers={})
         self.assertEqual(404, code)
+
+    @tornado.testing.gen_test
+    def test_check_failure(self):
+        code, response = yield checker.check_http("foo", self.get_http_port(), "/redirect", io_loop=self.io_loop, query_params="", headers={})
+        self.assertEqual(301, code)
 
     @tornado.testing.gen_test
     def test_check_failure_with_code(self):


### PR DESCRIPTION
This PR entered Yelp's fork in https://github.com/Yelp/hacheck/pull/4

If a service being healthchecked happens to return a redirect, I want to treat that as healthy. If it needs to know about some upstream service's health, that's its job to do, not mine. Don't follow redirects.
