### PR TITLE
Agent protocol support

### DIFF
--- a/hacheck/agent_server.py
+++ b/hacheck/agent_server.py
@@ -1,0 +1,20 @@
+from . import spool
+
+from tornado.gen import coroutine
+from tornado.tcpserver import TCPServer
+
+
+class AgentServer(TCPServer):
+    def __init__(self, io_loop=None):
+        super(AgentServer, self).__init__(io_loop=io_loop)
+
+    @coroutine
+    def handle_stream(self, stream, address):
+        service_name = (yield stream.read_until(b'\n')).decode('utf-8').rstrip().split('/', 1)[0]
+        up, extra_info = spool.is_up(service_name)
+        if up:
+            yield stream.write('up\n'.encode('ascii'))
+        else:
+            yield stream.write('maint\n'.encode('ascii'))
+        stream.close()
+        return

--- a/hacheck/agent_server.py
+++ b/hacheck/agent_server.py
@@ -13,7 +13,7 @@ class AgentServer(TCPServer):
         service_name = (yield stream.read_until(b'\n')).decode('utf-8').rstrip().split('/', 1)[0]
         up, extra_info = spool.is_up(service_name)
         if up:
-            yield stream.write('up\n'.encode('ascii'))
+            yield stream.write('ready\n'.encode('ascii'))
         else:
             yield stream.write('maint\n'.encode('ascii'))
         stream.close()

--- a/hacheck/handlers.py
+++ b/hacheck/handlers.py
@@ -76,7 +76,11 @@ class BaseServiceHandler(tornado.web.RequestHandler):
             port = int(port)
             last_message = ""
             querystr = self.request.query
-            for this_checker in self.CHECKERS:
+            if self.settings['check_spool']:
+                checkers = [checker.check_spool] + self.CHECKERS
+            else:
+                checkers = self.CHECKERS
+            for this_checker in checkers:
                 code, message = yield this_checker(
                     service_name,
                     port,
@@ -103,32 +107,32 @@ class BaseServiceHandler(tornado.web.RequestHandler):
 
 
 class SpoolServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool]
+    CHECKERS = []
 
 
 class HTTPServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_http]
+    CHECKERS = [checker.check_http]
 
 
 class HaproxyServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_haproxy]
+    CHECKERS = [checker.check_haproxy]
 
 
 class TCPServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_tcp]
+    CHECKERS = [checker.check_tcp]
 
 
 class MySQLServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_mysql]
+    CHECKERS = [checker.check_mysql]
 
 
 class RedisSentinelServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_redis_sentinel]
+    CHECKERS = [checker.check_redis_sentinel]
 
 
 class RedisInfoServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_redis_info]
+    CHECKERS = [checker.check_redis_info]
 
 
 class SentinelInfoServiceHandler(BaseServiceHandler):
-    CHECKERS = [checker.check_spool, checker.check_sentinel_info]
+    CHECKERS = [checker.check_sentinel_info]

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -68,7 +68,7 @@ class AgentServerTestCase(tornado.testing.AsyncTestCase):
             stream.set_server_data(b'server\n')
             yield self.server.handle_stream(stream, None)
             response = stream.get_client_data()
-            self.assertEqual(response, b'up\n')
+            self.assertEqual(response, b'ready\n')
 
     @tornado.testing.gen_test
     def test_basic_down(self):

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -1,0 +1,80 @@
+import os
+
+from hacheck import agent_server
+from hacheck import spool
+
+import six
+import mock
+import tornado.concurrent
+import tornado.testing
+
+
+class StringIOStream(tornado.iostream.BaseIOStream):
+    def __init__(self, *args, **kwargs):
+        super(StringIOStream, self).__init__(*args, **kwargs)
+        # data from the server to the client
+        self.server_data = six.BytesIO()
+        # data from the client to the server
+        self.client_data = six.BytesIO()
+
+        self.client_offset_into_server_data = 0
+
+    def set_server_data(self, data):
+        self.server_data.write(data)
+
+    def get_client_data(self):
+        d = self.client_data.getvalue()
+        self.client_data = six.BytesIO()
+        return d
+
+    def read_until(self, delimiter):
+        rv = tornado.concurrent.Future()
+        response = six.BytesIO()
+        success = False
+        self.server_data.seek(self.client_offset_into_server_data)
+        while True:
+            c = self.server_data.read(1)
+            if not c:
+                break
+            response.write(c)
+            if c == delimiter:
+                rv.set_result(response.getvalue())
+                success = True
+                break
+        if success:
+            self.client_offset_info_server_data = self.server_data.tell()
+        self.server_data.seek(0, 2)
+        return rv
+
+    def write(self, data):
+        rv = tornado.concurrent.Future()
+        rv.set_result(None)
+        self.client_data.write(data)
+        return rv
+
+    def close(self):
+        pass
+
+
+class AgentServerTestCase(tornado.testing.AsyncTestCase):
+    def setUp(self):
+        super(AgentServerTestCase, self).setUp()
+        self.server = agent_server.AgentServer(io_loop=self.io_loop)
+
+    @tornado.testing.gen_test
+    def test_basic_up(self):
+        with mock.patch.object(spool, 'is_up', return_value=(True, {})):
+            stream = StringIOStream()
+            stream.set_server_data(b'server\n')
+            yield self.server.handle_stream(stream, None)
+            response = stream.get_client_data()
+            self.assertEqual(response, b'up\n')
+
+    @tornado.testing.gen_test
+    def test_basic_down(self):
+        with mock.patch.object(spool, 'is_up', return_value=(False, {'nope'})):
+            stream = StringIOStream()
+            stream.set_server_data(b'server\n')
+            yield self.server.handle_stream(stream, None)
+            response = stream.get_client_data()
+            self.assertEqual(response, b'maint\n')


### PR DESCRIPTION
Adds support for using HAProxy 1.7.x (or 1.6.x with a patch I wrote) with the agent protocol and `agent-send`.
- Adds `-A` argument which binds a new simple server on a different port. Use the `agent-send` parameter in your haproxy backends to send requests to this server.
- Adds `S` argument to disable returning spool (`haup` / `hadown`) results on regular healthchecks -- those are only returned on the agent server if you pass `-S`. That way, deploys and such will put servers in MAINT through the agent, not in DOWN through the regular check
